### PR TITLE
Fix runParserFully, add Flag'

### DIFF
--- a/Options/Applicative/Builder.idr
+++ b/Options/Applicative/Builder.idr
@@ -137,6 +137,9 @@ arg rdr f = OptP (f $ Opt defProps (ArgReader rdr "ARG"))
 strArg : (Option ArgParams String -> Option ArgParams String) -> Parser String
 strArg = arg Right
 
+flag' : a -> (Option FlagParams a -> Option FlagParams a) -> Parser a
+flag' d f = OptP (f $ Opt defProps (FlagReader [] d))
+
 flag : (Option FlagParams Bool -> Option FlagParams a) -> Parser a
 flag f = OptP (f $ Opt defProps (FlagReader [] True))
 

--- a/Options/Applicative/Run.idr
+++ b/Options/Applicative/Run.idr
@@ -83,8 +83,8 @@ runParser p args@(arg :: argt) = do
     _                => maybeToEither (parseError arg) $ map (\x' => (x', args)) (evalParser p)
 
 runParserFully : Parser a -> List String -> Either ParseError a
-runParserFully p Nil = do
-  (res,leftOver) <- runParser p Nil
+runParserFully p ls = do
+  (res,leftOver) <- runParser p ls
   case leftOver of
     (un :: _) => Left $ parseError un
     Nil       => Right res

--- a/Options/Applicative/Run.idr
+++ b/Options/Applicative/Run.idr
@@ -74,14 +74,15 @@ parseError arg = ErrorMsg msg
       ('-'::_) => "Invalid option `" ++ arg ++ "'"
       _        => "Invalid argument `" ++ arg ++ "'"
 
+total
 runParser : Parser a -> List String -> Either ParseError (a, List String)
 runParser p Nil = maybeToEither (ErrorMsg "Not enough input") $ map (\p' => (p', Nil)) (evalParser p)
 runParser p args@(arg :: argt) = do
-  x <- runStateT (runMaybeT $ stepParser p arg) argt
-  case x of
-    (Just p', args') => runParser p' args'
-    _                => maybeToEither (parseError arg) $ map (\x' => (x', args)) (evalParser p)
+  (Just p', args') <- runStateT (runMaybeT $ stepParser p arg) argt
+    | _ => maybeToEither (parseError arg) (map (\x' => (x', args)) (evalParser p))
+  assert_total $ runParser p' args'
 
+total
 runParserFully : Parser a -> List String -> Either ParseError a
 runParserFully p ls = do
   (res,leftOver) <- runParser p ls


### PR DESCRIPTION
Hi,

I tried to use optparse-idris for a project but I found a couple things worth fixing.

`runParserFully` was only specified for an argument list of `Nil`. The existing implementation seemed to be already handling the `Cons` case well so I've just replace the pattern match by a variable.

I also needed a `flag' : a -> (Option FlagParams a -> Option FlagParams a) -> Parser a` construct in order to toggle an optional argument. Tell me is this is a welcome addition.

Finally I've used the shortcut syntax of do-notation instead of relying on `case of` tell me if this is a welcome addition as well.

ps: I've tried using `help` but it seems like it's type signature doesn't return the same lens as `short` and `long` any pointers to help me generate the help field?